### PR TITLE
Update default.mustache

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -2,13 +2,13 @@
 Color={{base00-rgb-r}},{{base00-rgb-g}},{{base00-rgb-b}}
 
 [BackgroundIntense]
-Color={{base00-rgb-r}},{{base00-rgb-g}},{{base00-rgb-b}}
+Color={{base03-rgb-r}},{{base03-rgb-g}},{{base03-rgb-b}}
 
 [Color0]
 Color={{base00-rgb-r}},{{base00-rgb-g}},{{base00-rgb-b}}
 
 [Color0Intense]
-Color={{base00-rgb-r}},{{base00-rgb-g}},{{base00-rgb-b}}
+Color={{base03-rgb-r}},{{base03-rgb-g}},{{base03-rgb-b}}
 
 [Color1]
 Color={{base08-rgb-r}},{{base08-rgb-g}},{{base08-rgb-b}}


### PR DESCRIPTION
Other base16 themes (like base16-xresources) use base03 for bright black. Currently with base00, some texts are unreadable.